### PR TITLE
Add Link to GitHub Python Extensions Repo

### DIFF
--- a/src/_docs/extensions/python.md
+++ b/src/_docs/extensions/python.md
@@ -3,6 +3,7 @@ layout: docs
 title: Python extension
 permalink: /docs/extensions/python/
 ---
+To install and use Python extensions, follow the instructions in the [official repository for Python extensions](https://github.com/albertlauncher/python).
 
 The Python extension makes the application extendable by embedding Python modules. Since the name of the native extension providing this functionality is "Python extension" and a Python module in this context is called "Python extension" too, this article refers to the Python extensions by using the term *Python modules*.
 


### PR DESCRIPTION
It took me a long time to figure out how to install Python extensions (didn't see it in the docs). I had to Google it to find the repository and instructions. Hopefully adding this link to the docs will make it easier for others.