### PR TITLE
Simplifying installation a bit

### DIFF
--- a/src/_docs/installing.md
+++ b/src/_docs/installing.md
@@ -23,10 +23,7 @@ sudo rpm --import \
 
 while for deb based package managers you have to:
 ```bash
-wget -nv -O Release.key \
-  https://build.opensuse.org/projects/home:manuelschneid3r/public_key
-apt-key add - < Release.key
-apt-get update
+curl https://build.opensuse.org/projects/home:manuelschneid3r/public_key | sudo apt-key add -
 ```
 
 Now follow the instructions [here](https://software.opensuse.org/download.html?project=home:manuelschneid3r&package=albert).


### PR DESCRIPTION
I made the documentation parallel to rpm-based managers by only referring to importing the keys. I then simplified that command.