### PR TITLE
Add list of built-in python custom extensions

### DIFF
--- a/src/_docs/extensions.md
+++ b/src/_docs/extensions.md
@@ -29,3 +29,44 @@ There are several extensions that get shipped together with the main albert core
 - Terminal
 - [VirtualBox](/docs/extensions/virtualbox/)
 - [Websearch](/docs/extensions/websearch/)
+
+## Custom python extensions
+
+- Arch Wiki
+- Atom Projects
+- AUR
+- Base Converter
+- Binance
+- Bitfinex
+- CoinMarketCap
+- CopyQ
+- Currency converter
+- Dango Emoji
+- Dango Kaomoji
+- DateTime
+- Gnome Dictionary
+- Gnote
+- Golden Dictionary
+- Google Translate
+- IP Addresses
+- Jetbrains IDE Projects
+- Kill Process
+- Locate
+- Mathematica Expressions
+- Multi-lang Google Translate
+- NPM
+- Packagist
+- Pacman
+- Pass
+- Pidgin
+- Pomodoro
+- Python
+- Scrot
+- TeX to Unicode
+- Timer
+- Tomboy
+- Trash
+- Units
+- Wikipedia
+- Youtube
+- Zeal


### PR DESCRIPTION
When I didn't know what Albert is and googled project for the first time, I found [Extensions doc](https://albertlauncher.github.io/docs/extensions/) page and was impressed by the variety of available extensions. 

But this page is missing available python custom extensions and I think it's really important to let potential users know about them: these plugins make Albert way more useful and powerful.

In this PR I'm suggesting to add this list of available extensions to the doc page. What do you think?