### PR TITLE
Add install instructions for Ubuntu 21.10

### DIFF
--- a/src/_pages/installing.md
+++ b/src/_pages/installing.md
@@ -42,15 +42,26 @@ To find the link of the distribution you need visit [the OBS software repo](http
 
 These steps have to be done only once. From now on Albert will be updated like any other package on your system.
 
+### Install on Ubuntu 20.04
 ```bash
-# Full example for Ubuntu 20.04
 curl https://build.opensuse.org/projects/home:manuelschneid3r/public_key | sudo apt-key add -
 echo 'deb http://download.opensuse.org/repositories/home:/manuelschneid3r/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/home:manuelschneid3r.list
 sudo wget -nv https://download.opensuse.org/repositories/home:manuelschneid3r/xUbuntu_20.04/Release.key -O "/etc/apt/trusted.gpg.d/home:manuelschneid3r.asc"
 sudo apt update
 sudo apt install albert
+```
 
-# Full example for Fedora 33
+### Install on Ubuntu 21.10
+```bash
+curl https://build.opensuse.org/projects/home:manuelschneid3r/public_key | sudo apt-key add -
+echo 'deb http://download.opensuse.org/repositories/home:/manuelschneid3r/xUbuntu_21.10/ /' | sudo tee /etc/apt/sources.list.d/home:manuelschneid3r.list
+sudo wget -nv https://download.opensuse.org/repositories/home:manuelschneid3r/xUbuntu_21.10/Release.key -O "/etc/apt/trusted.gpg.d/home:manuelschneid3r.asc"
+sudo apt update
+sudo apt install albert
+```
+
+### Install on Fedora 33
+```bash
 sudo rpm --import https://build.opensuse.org/projects/home:manuelschneid3r/public_key
 dnf config-manager --add-repo https://download.opensuse.org/repositories/home:manuelschneid3r/Fedora_33/home:manuelschneid3r.repo
 dnf install albert


### PR DESCRIPTION
Add install instructions for Ubuntu 21.10 and divide instructions in h3 headers for Ubuntu 20.04, 21.10 and Fedora.