### PR TITLE
Fix docs link

### DIFF
--- a/src/_pages/extension.md
+++ b/src/_pages/extension.md
@@ -12,4 +12,4 @@ The native way is to use C++/Qt to write a QPlugin. This gives you the performan
 
 ## Python plugins
 
-The Python plugin adds plugins via Python modules. Check the docs of the [Python plugin](https://github.com/albertlauncher/plugins/blob/master/python/README.md) and the [`python`](https://github.com/albertlauncher/python) repo for an up to date list of plugins.
+The Python plugin adds plugins via Python modules. Check the docs of the [Python plugin](https://github.com/albertlauncher/python) and the [`python`](https://github.com/albertlauncher/python) repo for an up to date list of plugins.


### PR DESCRIPTION
## Changes

This Pull Request aims to fix broken links on the page causing 404 errors.

### Before

Broken link: https://github.com/albertlauncher/plugins/blob/master/python/README.md

### After

Fixed link: https://github.com/albertlauncher/python


It might have been intended to create a README.md file in this repository. If so, it's okay to close it.
https://github.com/albertlauncher/plugins/tree/master/python




I'm using Albert. Thank you for your continued support.
